### PR TITLE
Change homepage banner

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,6 +1,6 @@
 import { Cards, Card, Callout } from 'nextra/components'
 
-![2header](/assets/2header.png)
+![Banner](https://github.com/user-attachments/assets/06e27b6f-dec8-49b1-87af-4305b96cb2f0)
 
 ## What is Baseline?
 


### PR DESCRIPTION
Updated the homepage banner to the new image as requested in issue #46.

Changes:
- Updated banner reference in `pages/index.mdx`
- Changed from `/assets/2header.png` to new GitHub URL

Closes #46


Generated with [Claude Code](https://claude.ai/code)