### PR TITLE
Issue #48: Add banner to How Baseline Works page

### DIFF
--- a/pages/how-baseline-works.mdx
+++ b/pages/how-baseline-works.mdx
@@ -1,5 +1,7 @@
 import { Callout } from "nextra/components";
 
+<img src="https://github.com/user-attachments/assets/c33bfc06-76ad-4c56-9d45-58c20847db58" alt="How Baseline Works Banner" width="100%" style={{ maxWidth: '1500px', height: 'auto' }} />
+
 ## How Baseline Works
 Most tokens still rely on external market makers to keep trading alive, systems that are often opaque, 
 extractive, and prone to failure during volatility. 


### PR DESCRIPTION
This PR adds a banner to the top of the "How Baseline Works" page as requested in issue #48.

## Changes
- Added banner image to top of pages/how-baseline-works.mdx
- Banner is responsive and will scale with page width
- Includes proper alt text for accessibility

Generated with [Claude Code](https://claude.ai/code)