### PR TITLE
Add banner component and update color palette to Radix UI Lime

### DIFF
--- a/components/banner.module.css
+++ b/components/banner.module.css
@@ -1,0 +1,76 @@
+.banner {
+  position: relative;
+  width: 100%;
+  height: 200px;
+  margin-bottom: 2rem;
+  border-radius: 12px;
+  overflow: hidden;
+  background: linear-gradient(135deg, #bdee63 0%, #8db654 50%, #5c7c2f 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bannerContent {
+  position: relative;
+  z-index: 2;
+  text-align: center;
+  padding: 2rem;
+}
+
+.bannerTitle {
+  font-size: 3rem;
+  font-weight: 700;
+  color: #37401c;
+  margin: 0 0 1rem 0;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.bannerSubtitle {
+  font-size: 1.25rem;
+  color: #37401c;
+  margin: 0;
+  opacity: 0.9;
+  font-weight: 500;
+}
+
+.bannerGradient {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, rgba(189, 238, 99, 0.9) 0%, rgba(141, 182, 84, 0.8) 50%, rgba(92, 124, 47, 0.9) 100%);
+  z-index: 1;
+}
+
+/* Dark theme adjustments */
+:global(.dark) .banner {
+  background: linear-gradient(135deg, #46a758 0%, #2f6e3b 50%, #1d4427 100%);
+}
+
+:global(.dark) .bannerTitle {
+  color: #e5fbeb;
+}
+
+:global(.dark) .bannerSubtitle {
+  color: #e5fbeb;
+}
+
+:global(.dark) .bannerGradient {
+  background: linear-gradient(135deg, rgba(70, 167, 88, 0.9) 0%, rgba(47, 110, 59, 0.8) 50%, rgba(29, 68, 39, 0.9) 100%);
+}
+
+@media (max-width: 768px) {
+  .banner {
+    height: 150px;
+  }
+  
+  .bannerTitle {
+    font-size: 2rem;
+  }
+  
+  .bannerSubtitle {
+    font-size: 1rem;
+  }
+}

--- a/components/banner.tsx
+++ b/components/banner.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import styles from './banner.module.css'
+
+interface BannerProps {
+  title?: string
+  subtitle?: string
+}
+
+export function Banner({ title, subtitle }: BannerProps) {
+  return (
+    <div className={styles.banner}>
+      <div className={styles.bannerContent}>
+        {title && <h1 className={styles.bannerTitle}>{title}</h1>}
+        {subtitle && <p className={styles.bannerSubtitle}>{subtitle}</p>}
+      </div>
+      <div className={styles.bannerGradient} />
+    </div>
+  )
+}

--- a/pages/what-can-i-do.mdx
+++ b/pages/what-can-i-do.mdx
@@ -1,5 +1,7 @@
 import { Cards, Card } from 'nextra/components'
+import { Banner } from '../components/banner'
 
+<Banner title="What Can I Do With Baseline?" subtitle="Discover the possibilities with intelligent liquidity" />
 
 # What Can I Do With Baseline?
 

--- a/public/assets/custom.css
+++ b/public/assets/custom.css
@@ -1,5 +1,66 @@
 /* custom.css */
 
+/* Radix UI Lime Color Palette */
+:root {
+  --lime1: #fcfdfa;
+  --lime2: #f8faf3;
+  --lime3: #eef6d6;
+  --lime4: #e2f0bd;
+  --lime5: #d3e7a6;
+  --lime6: #c2da91;
+  --lime7: #abc978;
+  --lime8: #8db654;
+  --lime9: #bdee63;
+  --lime10: #b0e64c;
+  --lime11: #5c7c2f;
+  --lime12: #37401c;
+}
+
+/* Dark theme Radix UI Lime colors */
+.dark {
+  --lime1: #0d1912;
+  --lime2: #0f1e13;
+  --lime3: #132819;
+  --lime4: #16301d;
+  --lime5: #193921;
+  --lime6: #1d4427;
+  --lime7: #245530;
+  --lime8: #2f6e3b;
+  --lime9: #46a758;
+  --lime10: #55b467;
+  --lime11: #63c174;
+  --lime12: #e5fbeb;
+}
+
+/* Apply lime colors to key elements */
+:root {
+  --nextra-primary-hue: 89;
+  --nextra-primary-saturation: 65%;
+}
+
+/* Custom accent color using Radix UI Lime */
+.nextra-nav-container {
+  border-bottom-color: var(--lime6);
+}
+
+/* Links and interactive elements */
+a {
+  color: var(--lime11);
+}
+
+a:hover {
+  color: var(--lime10);
+}
+
+.dark a {
+  color: var(--lime11);
+}
+
+.dark a:hover {
+  color: var(--lime10);
+}
+
+/* Sidebar styling */
 .sidebar-group {
   display: none;
 }

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -16,7 +16,7 @@ const config: DocsThemeConfig = {
   footer: {
     text: 'Baseline docs',
   },
-  // primaryHue: 89,
+  primaryHue: 89,
   nextThemes: {
     defaultTheme: 'dark',
     storageKey: 'theme'


### PR DESCRIPTION
Add Banner component with gradient styling using Radix UI Lime colors

## Changes
- Add Banner component with gradient styling using Radix UI Lime colors
- Update what-can-i-do.mdx to include banner at top of page
- Enable primaryHue: 89 in theme configuration for lime color scheme
- Add comprehensive Radix UI Lime color variables to custom.css
- Apply lime colors to links, navigation, and interactive elements
- Support both light and dark themes with appropriate color variations

Fixes #50

🤖 Generated with [Claude Code](https://claude.ai/code)