### PR TITLE
Remove emoji from 'What Can I Do?' title and add banner image

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -12,7 +12,7 @@
         }
     },
     "what-can-i-do": {
-        "title": "👤 What Can I Do?",
+        "title": "What Can I Do?",
         "theme": {
             "breadcrumb": true
         }

--- a/pages/what-can-i-do.mdx
+++ b/pages/what-can-i-do.mdx
@@ -1,5 +1,6 @@
 import { Cards, Card } from 'nextra/components'
 
+<img src="https://github.com/user-attachments/assets/e8201667-db87-47bf-84a9-2d448ea9678d" alt="Banner" width="1500" height="500" style={{width: '100%', height: 'auto', maxWidth: '1500px'}} />
 
 # What Can I Do With Baseline?
 


### PR DESCRIPTION
Remove "👤" emoji from page title and add banner image at top of what-can-i-do page.

Changes:
- Remove "👤" emoji from page title in _meta.json
- Add banner image (1500x500) at top of what-can-i-do.mdx page
- Image is responsive with proper styling

Fixes #52

Generated with [Claude Code](https://claude.ai/code)