### PR TITLE
Remove page title and add banner image to what-can-i-do page

### DIFF
--- a/pages/what-can-i-do.mdx
+++ b/pages/what-can-i-do.mdx
@@ -1,7 +1,6 @@
 import { Cards, Card } from 'nextra/components'
 
-
-# What Can I Do With Baseline?
+<img src="https://github.com/user-attachments/assets/e8201667-db87-47bf-84a9-2d448ea9678d" alt="Banner" width="1500" height="500" style={{width: '100%', height: 'auto', display: 'block'}} />
 
 Baseline offers different experiences depending on your goals.
 


### PR DESCRIPTION
Remove page title from what-can-i-do page while keeping emoji in navigation sidebar.

Changes:
- Remove '# What Can I Do With Baseline?' title from page content
- Add banner image (1500x500) at top of page
- Keep '👤 What Can I Do?' title in navigation sidebar

Fixes #52

Generated with [Claude Code](https://claude.ai/code)