### PR TITLE
Hide breadcrumb text and add banner image to what-can-i-do page

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -14,7 +14,7 @@
     "what-can-i-do": {
         "title": "👤 What Can I Do?",
         "theme": {
-            "breadcrumb": true
+            "breadcrumb": false
         }
     },
     "creator": {

--- a/pages/what-can-i-do.mdx
+++ b/pages/what-can-i-do.mdx
@@ -1,5 +1,6 @@
 import { Cards, Card } from 'nextra/components'
 
+<img src="https://github.com/user-attachments/assets/e8201667-db87-47bf-84a9-2d448ea9678d" width="1500" height="500" style={{width: '100%', height: 'auto', maxWidth: '1500px', display: 'block', margin: '0 auto'}} />
 
 # What Can I Do With Baseline?
 


### PR DESCRIPTION
Hide breadcrumb text and add banner image to what-can-i-do page

- Set breadcrumb: false in _meta.json to hide '👤 What Can I Do?' breadcrumb text
- Add banner image (1500x500) at top of page with responsive styling
- Keep main page title 'What Can I Do With Baseline?' visible

Fixes #52

Generated with [Claude Code](https://claude.ai/code)