### PR TITLE
Remove headline and hide breadcrumb text from what-can-i-do page

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -14,7 +14,7 @@
     "what-can-i-do": {
         "title": "👤 What Can I Do?",
         "theme": {
-            "breadcrumb": true
+            "breadcrumb": false
         }
     },
     "creator": {

--- a/pages/what-can-i-do.mdx
+++ b/pages/what-can-i-do.mdx
@@ -1,8 +1,6 @@
 import { Cards, Card } from 'nextra/components'
 
 
-# What Can I Do With Baseline?
-
 Baseline offers different experiences depending on your goals.
 
 


### PR DESCRIPTION
Remove headline and hide breadcrumb text from what-can-i-do page

- Remove '# What Can I Do With Baseline?' headline from page content
- Set breadcrumb to false in _meta.json to hide breadcrumb text

Fixes #52

Generated with [Claude Code](https://claude.ai/code)