### PR TITLE
Hide breadcrumb text, remove headline and body copy, add banner image

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -14,7 +14,7 @@
     "what-can-i-do": {
         "title": "👤 What Can I Do?",
         "theme": {
-            "breadcrumb": true
+            "breadcrumb": false
         }
     },
     "creator": {

--- a/pages/what-can-i-do.mdx
+++ b/pages/what-can-i-do.mdx
@@ -1,9 +1,7 @@
 import { Cards, Card } from 'nextra/components'
 
+<img src="https://github.com/user-attachments/assets/4e6c49c4-6c06-4b6a-a60c-5c7e6ed935d2" alt="Banner" style={{width: '100%', height: 'auto', maxWidth: '1500px', aspectRatio: '3/1', borderRadius: '8px', marginBottom: '2rem'}} />
 
-# What Can I Do With Baseline?
-
-Baseline offers different experiences depending on your goals.
 
 
 ## For Creators: Launch a better token


### PR DESCRIPTION
Hide breadcrumb text, remove headline and body copy, add banner image to what-can-i-do page

- Set breadcrumb: false in _meta.json to hide ‘👤 What Can I Do?’ breadcrumb text
- Remove ‘What Can I Do With Baseline?’ headline from page content
- Remove ‘Baseline offers different experiences depending on your goals.’ body copy
- Add new banner image (1500x500) at top of page with responsive styling

Fixes #52

Generated with [Claude Code](https://claude.ai/code)